### PR TITLE
config: Fix multiple "SAVE_CONFIG" section

### DIFF
--- a/klipper firmware/Voron 2.4 config/printer_v1.cfg
+++ b/klipper firmware/Voron 2.4 config/printer_v1.cfg
@@ -207,7 +207,7 @@ max_adjust: 30
 pin:!PB13
 x_offset: 0
 y_offset: 25.0
-z_offset: 3.3
+z_offset: 0
 speed: 10.0
 samples: 2
 samples_result: median
@@ -456,12 +456,6 @@ gcode:
     G0  X125 Y250 F3600            ; park nozzle at rear
     BED_MESH_CLEAR
 
-#*# <---------------------- SAVE_CONFIG ---------------------->
-#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
-#*#
-#*# [probe]
-#z_offset = 3.600
-
 [virtual_sdcard]
 path: ~/gcode_files
 
@@ -474,32 +468,4 @@ gcode:
   TURN_OFF_HEATERS
   CANCEL_PRINT_BASE
 
-
 [display_status]
-
-#*# <---------------------- SAVE_CONFIG ---------------------->
-#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
-#*#
-#*# [probe]
-#*# z_offset = 3.399
-
-#*# <---------------------- SAVE_CONFIG ---------------------->
-#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
-#*#
-#*# [probe]
-#*# z_offset = 3.299
-
-#*# <---------------------- SAVE_CONFIG ---------------------->
-#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
-#*#
-#*# [probe]
-##z_offset = -2.001
-
-#*# <---------------------- SAVE_CONFIG ---------------------->
-#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
-#*#
-#*# [heater_bed]
-#*# control = pid
-#*# pid_kp = 71.039
-#*# pid_ki = 2.223
-#*# pid_kd = 567.421

--- a/klipper firmware/Voron 2.4 config/printer_v2.cfg
+++ b/klipper firmware/Voron 2.4 config/printer_v2.cfg
@@ -207,7 +207,7 @@ max_adjust: 30
 pin:!PB12
 x_offset: 0
 y_offset: 25.0
-z_offset: 3.6
+z_offset: 0
 speed: 10.0
 samples: 2
 samples_result: median
@@ -237,7 +237,7 @@ interpolate: True
 run_current: 0.8
 hold_current: 0.3
 sense_resistor: 0.110
-stealthchop_threshold: 9999
+stealthchop_threshold: 0
 
 [tmc2209 stepper_y]
 uart_pin: PE3
@@ -245,7 +245,7 @@ interpolate: True
 run_current: 0.8
 hold_current: 0.3
 sense_resistor: 0.110
-stealthchop_threshold: 9999
+stealthchop_threshold: 0
 
 [tmc2209 stepper_z]
 uart_pin: PB7
@@ -260,7 +260,7 @@ interpolate: True
 run_current: 0.6
 hold_current: 0.5
 sense_resistor: 0.110
-stealthchop_threshold: 9999
+stealthchop_threshold: 0
 
 [tmc2209 stepper_z1]
 uart_pin: PD4
@@ -456,12 +456,6 @@ gcode:
     G0  X125 Y250 F3600            ; park nozzle at rear
     BED_MESH_CLEAR
 
-#*# <---------------------- SAVE_CONFIG ---------------------->
-#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
-#*#
-#*# [probe]
-#z_offset = 3.600
-
 [virtual_sdcard]
 path: ~/gcode_files
 
@@ -474,32 +468,4 @@ gcode:
   TURN_OFF_HEATERS
   CANCEL_PRINT_BASE
 
-
 [display_status]
-
-#*# <---------------------- SAVE_CONFIG ---------------------->
-#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
-#*#
-#*# [probe]
-#*# z_offset = 3.399
-
-#*# <---------------------- SAVE_CONFIG ---------------------->
-#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
-#*#
-#*# [probe]
-#*# z_offset = 3.299
-
-#*# <---------------------- SAVE_CONFIG ---------------------->
-#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
-#*#
-#*# [probe]
-##z_offset = -2.001
-
-#*# <---------------------- SAVE_CONFIG ---------------------->
-#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
-#*#
-#*# [heater_bed]
-#*# control = pid
-#*# pid_kp = 71.039
-#*# pid_ki = 2.223
-#*# pid_kd = 567.421


### PR DESCRIPTION
fix multiple `SAVE_CONFIG` section.

These configuration files contain more than one `SAVE_CONFIG` section

File Change:
`MKS-Monster8\klipper firmware\Voron 2.4 config\printer_v1.cfg` 
`MKS-Monster8\klipper firmware\Voron 2.4 config\printer_v2.cfg`